### PR TITLE
Jadbio final models

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ Model platform name differs for each method, see below:
 + Additional method details found in [subSCOPE README](subscope/README.md)
 
 ### JADBio options
-+ Model options: `MULTI, CNVR, GEXP, METH, MIR, MUTA`
++ Model options: `MULTI, CNVR, GEXP, METH, MIR, MUTA` where `MULTI` stands for using all available data types.
 + Additional method details found in [JADBio README](jadbio/README.md)
+
 
 # Acknowledgment and Funding
 We would like to thank the National Cancer Institute for the support.

--- a/README.md
+++ b/README.md
@@ -121,19 +121,23 @@ Examples for BRCA cancer cohorts are:
 An example of how to run the prediction workflow is shown [here](tutorial/README.md) using SK Grid best performing gene expression model on a breast cancer cBioPortal dataset.
 
 # Alternative Model Download (Optional)
-Docker images for methods are automatically pulled and built by CWL workflows and tools from the public Synapse repository. Alternatively, Docker images can be manually downloaded and built using:
+Docker images for methods are automatically pulled and built by CWL workflows and tools from the public Synapse repository.
+
+Alternatively:
+1. Docker images can be manually downloaded by going to the publication page for each method image file.
+| ImageFile |
+|---|
+| sk_grid.tar.gz |
+| aklimate.tar.gz |
+| cloudforest.tar.gz |
+| jadbio.tar.gz |
+| subscope.tar.gz |
+
+2. Build each method's docker image.
 ```
-synapse get <synapse-ID>
 docker load -i <imagefile.tar.gz>
 ```
-
-| SynapseID | ImageFile |
-|----|---|
-| syn29658355  | sk_grid.tar.gz |
-| syn29659459  | aklimate.tar.gz |
-| syn30267068  | cloudforest.tar.gz |
-| syn31114207  | jadbio.tar.gz |
-| syn30993770 | subscope.tar.gz |
+Check these images have been successfully loaded with `docker images`.
 
 Note that some methods have an additional model data file to run. These can be found at the publication page (see section Download Method Model Data)
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ Docker images for methods are automatically pulled and built by CWL workflows an
 
 Alternatively:
 1. Docker images can be manually downloaded by going to the publication page for each method image file.
-| ImageFile |
-|---|
-| sk_grid.tar.gz |
-| aklimate.tar.gz |
-| cloudforest.tar.gz |
-| jadbio.tar.gz |
-| subscope.tar.gz |
+```
+# ImageFiles
+sk_grid.tar.gz
+aklimate.tar.gz
+cloudforest.tar.gz
+jadbio.tar.gz
+subscope.tar.gz
+```
 
 2. Build each method's docker image.
 ```

--- a/RUN_MODEL.sh
+++ b/RUN_MODEL.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Example: bash RUN_model.sh BRCA GEXP cloudforest user-transformed-data/transformed-data.tsv
-# Example: bash RUN_MODEL.sh BRCA TOP aklimate example_inputs_cancers/example_BRCA.tsv
+# Example: bash RUN_MODEL.sh BRCA GEXP aklimate example_inputs_cancers/example_BRCA.tsv
 # Example: bash RUN_MODEL.sh BRCA GEXP skgrid user-transformed-data/transformed-data.tsv
 # Example: bash RUN_MODEL.sh BRCA GEXP subscope example_inputs_cancers/example_BRCA.tsv
 # Example: bash RUN_MODEL.sh BRCA GEXP jadbio example_inputs_cancers/example_BRCA.tsv

--- a/jadbio/README.md
+++ b/jadbio/README.md
@@ -1,3 +1,6 @@
 # JADBio
 ### Predictions file
 Each run of a JADBio model produces a single csv results file, where the first column contains the sample ID, while the following columns contain the probability for each cancer subtype. The overall predicted subtype can be determined by taking the largest probability for each sample.
+
+# Notes on platforms
+JADBio does not include MIR models for `KIRCKICH`, `LGGGBM` or `LIHCCHOL`

--- a/tools/options.yml
+++ b/tools/options.yml
@@ -750,6 +750,12 @@ jadbio:
     - METH
     - MULTI
     - MUTA
+  LIHCCHOL:
+    - CNVR
+    - GEXP
+    - METH
+    - MULTI
+    - MUTA
   LUAD:
     - CNVR
     - GEXP
@@ -793,14 +799,17 @@ jadbio:
     - MULTI
     - MUTA
   PRAD:
+    - CNVR
     - GEXP
     - METH
     - MIR
+    - MULTI
     - MUTA
   SARC:
     - CNVR
     - GEXP
     - METH
+    - MIR
     - MULTI
     - MUTA
   SKCM:
@@ -808,18 +817,22 @@ jadbio:
     - GEXP
     - METH
     - MIR
+    - MULTI
+    - MUTA
   TGCT:
     - CNVR
     - GEXP
     - METH
     - MIR
     - MULTI
+    - MUTA
   THCA:
     - CNVR
     - GEXP
     - METH
     - MIR
     - MULTI
+    - MUTA
   THYM:
     - CNVR
     - GEXP


### PR DESCRIPTION
All models for JADBio reported and tests ran for qc of inputs and output for each step. JADBio now reports the top model for each of these categories: GEXP, MUTA, METH, CNVR, MIR,  and MULTI.

updated yaml file with acceptable models for method.

updated readme with instructions on where to manually download docker images (secondary method, primary method still automatically built into CWL workflows and tools)