### PR TITLE
optional slicing of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ python tools/convert.py \
 	--out <relabeled-user-data> \
 	--cancer <cancer>
 ```
+An optional argument of `--delete_i_col` can be included. An optional argument to inform which column to remove (0 based indexing). Use if a meta-data column is in data. If not specified, then will run with no column deletions.
 
 ### 1B. Quantile Rescaling
 Second, relabeled data must be transformed with a quantile rescale prior to running machine learning algorithms. The rescaled output file will always be located in `user-transformed-data/transformed-data.tsv`.

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -10,14 +10,16 @@ parser.add_argument("--cancer", help="cancer cohort")
 parser.add_argument("--data", help="input data to be transformed, must be tsv")
 parser.add_argument("--conversion_file", default='tools/entrez2tmp_BRCA_GEXP.json', help="conversion file to map input fts to TMP feature names. default value ideal for most cases")
 parser.add_argument("--out", help="name of output file")
+parser.add_argument("--delete_i_col", default=0, type=int, help="index number of col to remove, eg. 1. note this is zero based indexing. default is 0 for no deletion")
 args = parser.parse_args()
 
 
 # From cbioportal data - convert to TMP-ft-id and format
 df = pd.read_csv(args.data, sep='\t')
 
-# Filter out  extra info and nan
-df = df.iloc[:, 1:]
+# Filter out  extra info (optional)
+df = df.iloc[:, args.delete_i_col:]
+
 df = df.dropna()
 
 # Open conversion file and convert

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -25,8 +25,10 @@ First, machine learning models need to be able to match genes to GDAN-TMP specif
 python tools/convert.py \
 	--data brca_metabric/data_mrna_agilent_microarray.txt \
 	--out user-transformed-data/cbioportal_BRCA_GEXP.tsv \
-	--cancer BRCA
+	--cancer BRCA \
+	--delete_i_col 1 # this last line is dataset specific. 0 based index
 ```
+Note that the `--delete_i_col` is an optional argument to inform which column to remove (in this case the METABRIC data has a metadata column at index 1 so we will delete this).
 
 Second, data must be transformed with a quantile rescale prior to running machine learning algorithms. The output file can be found at `user-transformed-data/transformed-data.tsv`
 ```


### PR DESCRIPTION
An optional argument of `--delete_i_col` can be included. An optional argument to inform which column to remove (0 based indexing). Use if a meta-data column is in data. If not specified, then will run with no column deletions.